### PR TITLE
[MyPage / Purchase] separate purchase state And Code Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,6 +2390,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
       "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
     },
+    "dayjs": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "axios": "^0.24.0",
+    "dayjs": "^1.10.7",
     "vue": "^3.2.20",
     "vue-router": "^4.0.12",
     "vuex": "^4.0.2"

--- a/src/components/PurchaseItem.vue
+++ b/src/components/PurchaseItem.vue
@@ -5,12 +5,12 @@
     <li>{{ purchase.timePaid }}</li>
     <li>{{ purchase.product.title }}</li>
     <li>{{ purchase.product.price }}</li>
-    <button @click="confirmed(purchase.detailId)">구매확인</button>
-    <button @click="cancle(purchase.detailId)" :disabled="purchase.done">
+    <button @click="confirmed">구매확인</button>
+    <button @click="cancle" :disabled="purchase.done">
           구매취소
     </button>
-    <li>{{ purchase.done }}</li>
-    <li>{{ purchase.isCanceled }}</li>
+    <li>{{ purchase.done? '구매확정 됨': '구매확정 전' }}</li>
+    <li>{{ purchase.isCanceled? '취소 됨': '취소 전' }}</li>
 
     <PurchaseDetailModal v-model="isModalShow" persistent >
       <template #activator>
@@ -45,17 +45,12 @@ export default {
     PurchaseDetailModal
   },
   methods: {
-    async cancle(id) {
-      this.$store.dispatch('user/CANCEL_PURCHASE', id)
-      await this.fetch()
+    async cancle() {
+      this.$store.dispatch('user/CANCEL_PURCHASE', { detailId: this.purchase.detailId})
     },
-    async confirmed(id) {
-      this.$store.dispatch('user/CONFIRM_PURCHASE', id)
-      await this.fetch()
+    async confirmed() {
+      this.$store.dispatch('user/CONFIRM_PURCHASE', { detailId: this.purchase.detailId})
     },
-    fetch() {
-      console.log('구매 내역 불러오기')
-    }
   }
 }
 </script>

--- a/src/components/PurchaseList.vue
+++ b/src/components/PurchaseList.vue
@@ -1,13 +1,32 @@
 <template>
-  <div>제품 전체 구매 내역이 보여지고 있다고 합니다</div>
+  <div>
+    <button @click="now = '구매'">구매 내역</button>
+    <button @click="now = '확정'">구매 확정 내역</button>
+    <button @click="now = '취소'">취소 내역</button>
+  </div>
+
   <div class="contents-box">
     <div v-if="!purchaseList.length">구매 신청 내역이 없습니다</div>
     <div v-else-if="isLoading">Loading...</div>
     <div v-else>
-      <PurchaseItem 
-        v-for="purchase in purchaseList"
-        :key="purchase.id"
-        :purchase="purchase" />
+      <template v-if="now === '구매'">
+        <PurchaseItem
+          v-for="purchase in purchaseList"
+          :key="purchase.id"
+          :purchase="purchase" />
+      </template>
+      <template v-if="now === '확정'">
+        <PurchaseItem
+          v-for="purchase in doneList"
+          :key="purchase.id"
+          :purchase="purchase" />
+      </template>
+      <template v-if="now === '취소'">
+        <PurchaseItem
+          v-for="purchase in canceledList"
+          :key="purchase.id"
+          :purchase="purchase" />
+      </template>
     </div>
   </div>
 </template>
@@ -22,11 +41,18 @@ export default {
   data() {
     return {
       isLoading: false,
+      now: '구매'
     }
   },
   computed: {
     purchaseList() {
-      return this.$store.state.user.purchaseList
+      return this.$store.getters["user/purchaseOnlyRequested"]
+    },
+    doneList() {
+      return this.$store.getters["user/purchaseOnlyDone"]
+    },
+    canceledList() {
+      return this.$store.getters["user/purchaseOnlyCanceled"]
     }
   },
   created() {

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -96,13 +96,11 @@ export default {
     },
     // 구매 확정
     async CONFIRM_PURCHASE({ commit }, payload) {
-      const { detailId } = payload
-      return await axiosUserProduct.post('ok', { detailId })
+      await axiosUserProduct.post('ok', payload)
     },
     // 구매 취소
     async CANCEL_PURCHASE({ commit }, payload) {
-      const { detailId } = payload
-      return await axiosUserProduct.post('cancel', { detailId })
+      await axiosUserProduct.post('cancel', payload)
     },
     async logOut() {
       await axiosAuth.post('logout')

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -52,6 +52,9 @@ export default {
     purchaseOnlyDone(state) {
       return state.purchaseList.filter((purchase) => purchase.done)
     },
+    purchaseOnlyRequested(state) {
+      return state.purchaseList.filter((purchase) => !purchase.done && !purchase.isCanceled)
+    },
   },
   // state에 있는 salesDetails에 data를 받아서 넣어줌
   mutations: {


### PR DESCRIPTION
- 구매 확정 구매 취소에 객체를 넘기 않아 생기던 버그 해결
- 일부 확인용 코드 확인을 완료하였기에 제거

- 구매 신청, 구매 확정, 구매 취소 목록을 구분하여 볼 수 있도록 구현

- 기타 : guards 통신 최적화

TODO 틀 잡기