### PR TITLE
[마이 페이지 레이아웃 및 본인 정보 수정 페이지 구현]

### DIFF
--- a/src/components/ChangeUserInfo.vue
+++ b/src/components/ChangeUserInfo.vue
@@ -1,5 +1,122 @@
 <template>
-  <div>
-    유저 정보 변경이 가능하다고 합니다
+  <div class="form-group">
+    <form class="input-group" @submit.prevent="updateInfo">
+      <h1>개인 정보 수정</h1>
+      <label for="user-name">이름</label>
+      <input
+        class="form-input"
+        v-model="displayName"
+        type="text"
+        id="user-name"
+        :placeholder="$route.query.name"
+      />
+      <label for="user-profile-picture">프로필 사진</label>
+      <input
+        class="form-input"
+        type="file"
+        id="user-profile-picture"
+        accept=".png, .jpg"
+        @change="selectfile"
+      />
+      <label for="old-password">기존 비밀번호</label>
+      <input
+        class="form-input"
+        v-model="oldPassword"
+        type="password"
+        id="old-password"
+        placeholder="기존 비밀번호을 입력하세요."
+        minlength="8"
+      />
+      <label for="new-password">새 비밀번호</label>
+      <input
+        class="form-input"
+        v-model="newPassword"
+        type="password"
+        id="new-password"
+        placeholder="새 비밀번호을 입력하세요."
+        minlength="8"
+      />
+
+      <input
+        @click="updateInfo"
+        class="btn-primary btn-16"
+        type="button"
+        value="정보 수정"
+      />
+    </form>
   </div>
 </template>
+
+<script>
+export default {
+  data() {
+    return {
+      displayName: '',
+      oldPassword: '',
+      newPassword: '',
+      profileImgBase64: '',
+      data: {},
+    }
+  },
+  methods: {
+    async updateInfo() {
+      this.data = await this.$store.dispatch('user/UPDATE_USERINFO', {
+        displayName: this.displayName,
+        oldPassword: this.oldPassword,
+        newPassword: this.newPassword,
+        profileImgBase64: this.profileImgBase64,
+      })
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.form-group {
+  @include column-flexbox();
+  width: 100%;
+
+  h1 {
+    @include text-style(32, $dark);
+    width: 360px;
+    font-weight: 300;
+    margin-bottom: 1em;
+  }
+
+  .input-group {
+    label {
+      @include text-style(12, $primary);
+      display: block;
+      width: 100%;
+    }
+
+    input {
+      display: block;
+      width: 360px;
+      padding-left: 12px;
+      margin-bottom: 12px;
+    }
+
+    input[type='file'] {
+      padding-top: 10px;
+      margin-bottom: 20px;
+      line-height: 1.1em;
+    }
+
+    input[type='button'] {
+      width: 360px;
+      margin-right: 20px;
+      cursor: pointer;
+    }
+  }
+
+  a {
+    @include flexbox();
+    position: absolute;
+    top: 40px;
+    left: 140px;
+    width: 80px;
+    margin-bottom: 12px;
+  }
+}
+</style>

--- a/src/routes/Home.vue
+++ b/src/routes/Home.vue
@@ -61,6 +61,7 @@ export default {
       this.$router.push('/')
     },
     async onKeyup(searchText) {
+      if (!searchText) return
       this.isSearchInput = true
       this.isResult = true
       this.searchText = searchText

--- a/src/routes/MyPage.vue
+++ b/src/routes/MyPage.vue
@@ -1,17 +1,134 @@
 <template>
-  <div class="my-info">
-    <RouterLink :to="{ name: 'PurchaseList'}">
-      구매 내역
-    </RouterLink>
-    <RouterLink :to="{ name: 'MyAccount'}">
-      내 계좌
-    </RouterLink>
-    <RouterLink :to="{ name: 'ChangeUserInfo'}">
-      내 정보 수정
-    </RouterLink>
-    <RouterLink to="/">
-      홈으로
-    </RouterLink>
+  <div class="container">
+    <div class="info-card">
+      <div class="profile">
+        <div class="image">
+          <img
+            :src="currentUser.profileImg"
+            :alt="`${currentUser.displayName}`"
+          />
+        </div>
+        <strong>{{ currentUser.displayName }}</strong>
+        <span>{{ currentUser.email }}</span>
+      </div>
+
+      <div class="my-info">
+        <RouterLink
+          class="btn-list btn-anchor btn-16"
+          :to="{ name: 'PurchaseList' }"
+        >
+          구매 내역
+        </RouterLink>
+        <RouterLink
+          class="btn-list btn-anchor btn-16"
+          :to="{ name: 'MyAccount' }"
+        >
+          내 계좌
+        </RouterLink>
+        <RouterLink
+          class="btn-list btn-anchor btn-16"
+          :to="{
+            name: 'ChangeUserInfo',
+            query: {
+              name: currentUser.displayName,
+            },
+          }"
+        >
+          내 정보 수정
+        </RouterLink>
+      </div>
+    </div>
+
+    <RouterView />
+    <RouterLink class="btn-anchor btn-16 move-home" to="/"> 홈으로 </RouterLink>
   </div>
-  <RouterView/>
 </template>
+
+<script>
+export default {
+  data() {
+    return {
+      isActive: 'active',
+    }
+  },
+  computed: {
+    currentUser() {
+      return this.$store.state.user.currentUser
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.container {
+  @include flexbox(center, center);
+  width: 100%;
+  padding: 100px 40px 20px;
+
+  .info-card {
+    @include column-flexbox(start, center);
+    position: relative;
+    width: 250px;
+    height: 380px;
+    margin-right: 50px;
+    padding: 20px 0;
+    border-radius: 6px;
+    border: 1px solid $border;
+
+    .btn-list {
+      display: block;
+      width: 140px;
+      border-left: none;
+      border-right: none;
+      border-radius: 0;
+      font-weight: 500;
+    }
+
+    .profile {
+      @include column-flexbox();
+      margin-bottom: 50px;
+
+      strong {
+        @include text-style(18, $dark);
+        margin-bottom: 4px;
+      }
+
+      span {
+        @include text-style(14, $primary);
+      }
+    }
+
+    .image {
+      @include flexbox();
+      width: 80px;
+      height: 80px;
+      margin-bottom: 14px;
+      padding: 6px 12px;
+      border: 1px solid $primary;
+      border-radius: 50%;
+
+      img {
+        display: block;
+        width: 100%;
+        object-fit: contain;
+      }
+    }
+
+    .my-info {
+      @include column-flexbox();
+
+      a {
+        @include flexbox();
+        padding: 0 6px;
+        font-size: 14px;
+      }
+    }
+  }
+}
+
+.move-home {
+  position: absolute;
+  top: 40px;
+  left: 40px;
+}
+</style>

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -78,6 +78,17 @@ export default {
       router.go()
       return data
     },
+    async UPDATE_USERINFO({ commit }, payload) {
+      const { displayName, oldPassword, newPassword, profileImgBase64 } =
+        payload
+      const { data } = axiosAuth.put('user', {
+        displayName,
+        oldPassword,
+        newPassword,
+        profileImgBase64,
+      })
+      return data
+    },
     // 제품 검색 결과 보기
     async SHOW_SEARCHRESULTS({ commit }, payload) {
       const { searchText, searchTags } = payload


### PR DESCRIPTION
마이 페이지 레이아웃
- 좌측에 기본 정보 카드 생성
- 구매내역, 내 계좌, 내 정보 수정 라우터 링크 배치
- 나머지 화면에 해당 라우터 페이지를 보여준다

본인 정보 수정 페이지
- 입력폼 
- 현재 이름 placeholder로 보여준다.
- 정보 수정 통신 확인