### PR TITLE
[Refactor] 로그인 로직, 판매내역 스토어 파일, 검색폼 리셋 개선

### DIFF
--- a/src/components/ChangeUserInfo.vue
+++ b/src/components/ChangeUserInfo.vue
@@ -55,12 +55,11 @@ export default {
       oldPassword: '',
       newPassword: '',
       profileImgBase64: '',
-      data: {},
     }
   },
   methods: {
     async updateInfo() {
-      this.data = await this.$store.dispatch('user/UPDATE_USERINFO', {
+      await this.$store.dispatch('user/UPDATE_USERINFO', {
         displayName: this.displayName,
         oldPassword: this.oldPassword,
         newPassword: this.newPassword,

--- a/src/components/PurchaseList.vue
+++ b/src/components/PurchaseList.vue
@@ -1,10 +1,4 @@
 <template>
-  <div>
-    <button @click="now = '구매'">구매 내역</button>
-    <button @click="now = '확정'">구매 확정 내역</button>
-    <button @click="now = '취소'">취소 내역</button>
-  </div>
-
   <div class="contents-box">
     <div v-if="!purchaseList.length">구매 신청 내역이 없습니다</div>
     <div v-else-if="isLoading">Loading...</div>
@@ -13,19 +7,22 @@
         <PurchaseItem
           v-for="purchase in purchaseList"
           :key="purchase.id"
-          :purchase="purchase" />
+          :purchase="purchase"
+        />
       </template>
       <template v-if="now === '확정'">
         <PurchaseItem
           v-for="purchase in doneList"
           :key="purchase.id"
-          :purchase="purchase" />
+          :purchase="purchase"
+        />
       </template>
       <template v-if="now === '취소'">
         <PurchaseItem
           v-for="purchase in canceledList"
           :key="purchase.id"
-          :purchase="purchase" />
+          :purchase="purchase"
+        />
       </template>
     </div>
   </div>
@@ -36,27 +33,27 @@ import PurchaseItem from '~/components/PurchaseItem'
 
 export default {
   components: {
-    PurchaseItem
+    PurchaseItem,
   },
   data() {
     return {
       isLoading: false,
-      now: '구매'
+      now: '구매',
     }
   },
   computed: {
     purchaseList() {
-      return this.$store.getters["user/purchaseOnlyRequested"]
+      return this.$store.getters['user/purchaseOnlyRequested']
     },
     doneList() {
-      return this.$store.getters["user/purchaseOnlyDone"]
+      return this.$store.getters['user/purchaseOnlyDone']
     },
     canceledList() {
-      return this.$store.getters["user/purchaseOnlyCanceled"]
-    }
+      return this.$store.getters['user/purchaseOnlyCanceled']
+    },
   },
   created() {
-    this.$store.dispatch("user/getPurchaseList")
-  }
+    this.$store.dispatch('user/getPurchaseList')
+  },
 }
 </script>

--- a/src/components/SalesDetails.vue
+++ b/src/components/SalesDetails.vue
@@ -1,31 +1,25 @@
 <template>
   <h2>판매 내역</h2>
-    <ul>
-      <li v-for="item in salesDetails" :key="item">{{ item }}</li>
-    </ul>
+  <ul>
+    <li v-for="item in salesDetails" :key="item">{{ item }}</li>
+  </ul>
 </template>
 
 <script>
-import { mapState, mapActions } from 'vuex'
-
+import { axiosAdminProduct } from '~/utils/productApiConfig'
 export default {
-  // [vuex] unknown action type: FETCH 에러가 나옴 ㅜ
   created() {
     this.fetch()
   },
   computed: {
-    ...mapState('user',{
-      salesDetails: 'salesDetails'
-    })
+    salesDetails() {
+      return this.$store.state.admin.salesDetails
+    },
   },
   methods: {
-    ...mapActions('user', ['SHOW_SALESDETAILS']),
-    fetch() {
-      this.SHOW_SALESDETAILS()
+    async fetch() {
+      await this.$store.dispatch('admin/SHOW_SALESDETAILS')
     },
-    onAddProduct() {
-      this.$router.push('/admin')
-    }
-  }
+  },
 }
 </script>

--- a/src/components/SignIn.vue
+++ b/src/components/SignIn.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="form-group">
     <h1>로그인</h1>
-    <form
-      class="input-group"
-      @submit="login(email, password)"
-    >
+    <form class="input-group" @submit="login(email, password)">
       <label for="user-email">이메일</label>
       <input
         class="form-input"
@@ -26,18 +23,15 @@
       <div class="buttons">
         <input
           class="btn-primary btn-16"
-          @click="login(email, password)"
+          @click="login"
           type="button"
           value="로그인"
-        >
-          <RouterLink
-            :to="{ name: 'SignUp' }"
-            class="btn-secondary btn-16"
-          >
-            회원가입
-            </RouterLink>
+        />
+        <RouterLink :to="{ name: 'SignUp' }" class="btn-secondary btn-16">
+          회원가입
+        </RouterLink>
       </div>
-      </form>
+    </form>
   </div>
 </template>
 
@@ -45,15 +39,18 @@
 export default {
   data() {
     return {
-      email: "",
-      password: ""
+      email: '',
+      password: '',
     }
   },
   methods: {
-    async login(email, password) {
-      await this.$store.dispatch("user/LOGIN", { email, password })
-    }
-  }
+    async login() {
+      await this.$store.dispatch('user/LOGIN', {
+        email: this.email,
+        password: this.password,
+      })
+    },
+  },
 }
 </script>
 
@@ -84,7 +81,7 @@ export default {
       margin-bottom: 12px;
     }
 
-    input[type="button"] {
+    input[type='button'] {
       width: 160px;
       margin-right: 20px;
     }

--- a/src/routes/Home.vue
+++ b/src/routes/Home.vue
@@ -3,6 +3,7 @@
   <div class="input-group">
     <i class="bx bx-search"></i>
     <input
+      @keyup.delete="onKeyReset(searchText)"
       @keyup.enter="onKeyup(searchText)"
       class="form-input"
       type="text"
@@ -24,7 +25,7 @@
   </div>
 
   <div v-if="isResult" class="items">
-    <div v-show="!data.legnth">검색 결과가 없습니다.</div>
+    <div v-show="!data.length">검색 결과가 없습니다.</div>
     <SearchResults :searchResults="searchResults" />
   </div>
 </template>
@@ -73,6 +74,10 @@ export default {
       this.searchText = ''
       this.isSearchInput = false
       this.isResult = false
+    },
+    onKeyReset(searchText) {
+      this.searchText = searchText
+      if (!this.searchText.length) this.resetQuery()
     },
   },
 }

--- a/src/store/admin.js
+++ b/src/store/admin.js
@@ -8,9 +8,10 @@ export default {
   namespaced: true,
   state: () => ({
     allProducts: [],
-    seletedProducts: []
+    seletedProducts: [],
+    salesDetails: [],
   }),
-  getters:{
+  getters: {
     // 제품의 전체 태그 보여주기
     tagSet(state) {
       const tagsRaw = []
@@ -28,9 +29,18 @@ export default {
     },
     addState(state, payload) {
       state.allProducts.push(payload)
-    }
+    },
+    SET_SALESDETAILS(state, salesDetails) {
+      state.salesDetails = salesDetails
+    },
   },
   actions: {
+    // 받아온 salesDetails를 활용하여 판매 내역 보기
+    async SHOW_SALESDETAILS({ commit }) {
+      const { data } = await axiosAdminProduct.get('transactions/all')
+      commit('SET_SALESDETAILS', { salesDetails: data })
+      return data
+    },
     async getAllProducts({ commit }) {
       const { data } = await axiosAdminProduct.get()
       commit('assignState', { allProducts: data })
@@ -40,7 +50,7 @@ export default {
       const seletedProducts = data.filter(item => item.tags.filter(tag => tags.includes(tag)).length)
       commit('assignState', { seletedProducts })
     },
-    async addProduct({commit}, obj) {
+    async addProduct({ commit }, obj) {
       const { data } = await axiosAdminProduct.post('', obj)
       commit('addState', data)
     }

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -17,7 +17,6 @@ export default {
   namespaced: true,
   state: () => ({
     purchaseList: [],
-    salesDetails: [],
     keywordList: [
       {
         name: 'GUCCI',
@@ -58,9 +57,7 @@ export default {
   },
   // state에 있는 salesDetails에 data를 받아서 넣어줌
   mutations: {
-    SET_SALESDETAILS(state, salesDetails) {
-      state.salesDetails = salesDetails
-    },
+
     assignState(state, payload) {
       Object.keys(payload).forEach((key) => {
         state[key] = payload[key]
@@ -102,12 +99,7 @@ export default {
       commit('SET_SEARCHRESULTS', data)
       return data
     },
-    // 받아온 salesDetails를 활용하여 판매 내역 보기
-    async SHOW_SALESDETAILS({ commit }) {
-      const { data } = await axiosAdminProduct.get('transactions/all')
-      await commit('SET_SALESDETAILS')
-      return data
-    },
+
     // 구매 확정
     async CONFIRM_PURCHASE({ commit }, payload) {
       await axiosUserProduct.post('ok', payload)


### PR DESCRIPTION
로그인
- 로직 리팩토링

판매내역 
- user store -> admin store 이동
- SalesDetails에 적용

검색폼 리셋 개선
- 검색어를 백스페이스로 지워서 아무것도 없을 때, 초기화면으로 이동
- 검색 결과 없어지고, 키워드 추천 보여줌